### PR TITLE
45308 : Add badge information to the iOS notification

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.push-notifications</groupId>
     <artifactId>exo-push-notifications</artifactId>
-    <version>2.2.x-SNAPSHOT</version>
+    <version>2.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo-push-notifications-addon-packaging</artifactId>
   <name>eXo Push notifications addon - Packaging</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </parent>
     <groupId>org.exoplatform.addons.push-notifications</groupId>
     <artifactId>exo-push-notifications</artifactId>
-    <version>2.2.x-SNAPSHOT</version>
+    <version>2.2.x-maintenance-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>eXo Add-on:: eXo Push notifications addon</name>
     <description>eXo Push notifications addon</description>
@@ -46,7 +46,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <!-- **************************************** -->
         <!-- Dependencies versions -->
         <!-- **************************************** -->
-        <org.exoplatform.social.version>6.2.x-SNAPSHOT</org.exoplatform.social.version>
+        <org.exoplatform.social.version>6.2.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <parent>
         <groupId>org.exoplatform.addons.push-notifications</groupId>
         <artifactId>exo-push-notifications</artifactId>
-        <version>2.2.x-SNAPSHOT</version>
+        <version>2.2.x-maintenance-SNAPSHOT</version>
     </parent>
     <artifactId>exo-push-notifications-service</artifactId>
     <name>eXo Push notifications addon - Service</name>

--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -33,6 +33,7 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.exoplatform.commons.api.notification.plugin.NotificationPluginUtils;
+import org.exoplatform.commons.api.notification.service.WebNotificationService;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.push.domain.Message;
@@ -68,6 +69,8 @@ public class FCMMessagePublisher implements MessagePublisher {
 
   private ResourceBundleService resourceBundleService;
 
+  private WebNotificationService webNotificationService;
+
   private CloseableHttpClient httpClient;
 
   private String fcmServiceAccountFilePath;
@@ -79,11 +82,11 @@ public class FCMMessagePublisher implements MessagePublisher {
   // How long (in seconds) the message should be kept in FCM storage if the device is offline
   private Integer fcmMessageExpirationTime = null;
 
-  public FCMMessagePublisher(InitParams initParams, ResourceBundleService resourceBundleService) {
-    this(initParams, resourceBundleService, HttpClientBuilder.create().build());
+  public FCMMessagePublisher(InitParams initParams, ResourceBundleService resourceBundleService, WebNotificationService webNotificationService) {
+    this(initParams, resourceBundleService, webNotificationService, HttpClientBuilder.create().build());
   }
 
-  public FCMMessagePublisher(InitParams initParams, ResourceBundleService resourceBundleService, CloseableHttpClient httpClient) {
+  public FCMMessagePublisher(InitParams initParams, ResourceBundleService resourceBundleService, WebNotificationService webNotificationService,  CloseableHttpClient httpClient) {
     if(initParams != null) {
       // FCM configuration file
       ValueParam serviceAccountFilePathValueParam = initParams.getValueParam("serviceAccountFilePath");
@@ -128,6 +131,7 @@ public class FCMMessagePublisher implements MessagePublisher {
 
     this.resourceBundleService = resourceBundleService;
     this.httpClient = httpClient;
+    this.webNotificationService = webNotificationService;
   }
 
   @Override
@@ -159,7 +163,8 @@ public class FCMMessagePublisher implements MessagePublisher {
               .append("    },")
               .append("    \"notification\": {")
               .append("      \"title\": \"").append(message.getTitle().replaceAll("\\<[^>]*>","").replaceAll("\"", "\\\\\"")).append("\",")
-              .append("      \"body\": \"").append(messageBody.replaceAll("\\<[^>]*>","")).append("\"")
+              .append("      \"body\": \"").append(messageBody.replaceAll("\\<[^>]*>","")).append("\",")
+              .append("      \"badge\": \"").append(webNotificationService.getNumberOnBadge(message.getReceiver())).append("\"")
               .append("    },");
     }
     if(fcmMessageExpirationTime != null && StringUtils.isNotBlank(message.getDeviceType())) {

--- a/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
+++ b/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
@@ -32,6 +32,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
+import org.exoplatform.commons.api.notification.service.WebNotificationService;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -58,6 +59,9 @@ public class FCMMessagePublisherTest {
   @Mock
   private CloseableHttpResponse httpResponse;
 
+  @Mock
+  private WebNotificationService webNotificationService;
+
   @Before
   public void setup() {
     ResourceBundle resourceBundle = new ResourceBundle() {
@@ -72,12 +76,13 @@ public class FCMMessagePublisherTest {
       }
     };
     when(resourceBundleService.getResourceBundle(eq("locale.portlet.notification.PushNotifications"), any(Locale.class))).thenReturn(resourceBundle);
+    when(webNotificationService.getNumberOnBadge(anyString())).thenReturn(5);
   }
 
   @Test
   public void shouldNotSendMessageWhenInitParamsAreNull() throws Exception {
     // Given
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(null, resourceBundleService, httpClient);
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(null, resourceBundleService, webNotificationService, httpClient);
 
     // When
     messagePublisher.send(new Message("", "", "", "", "", ""));
@@ -90,7 +95,7 @@ public class FCMMessagePublisherTest {
   public void shouldNotSendMessageWhenNoConfigFilePathParam() throws Exception {
     // Given
     InitParams initParams = new InitParams();
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient);
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient);
 
     // When
     messagePublisher.send(new Message("", "", "", "", "", ""));
@@ -107,7 +112,7 @@ public class FCMMessagePublisherTest {
     serverKeyParam.setName("serviceAccountFilePath");
     serverKeyParam.setValue("fake.json");
     initParams.addParameter(serverKeyParam);
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient);
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient);
 
     // When
     messagePublisher.send(new Message("", "", "", "", "", ""));
@@ -127,7 +132,7 @@ public class FCMMessagePublisherTest {
     serverKeyParam.setName("serviceAccountFilePath");
     serverKeyParam.setValue(this.getClass().getResource("/fcm-test.json").getPath());
     initParams.addParameter(serverKeyParam);
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient) {
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient) {
       @Override
       protected PrivateKey getPrivateKeyFromPkcs8(String privateKeyPem) throws IOException {
         return mock(PrivateKey.class);
@@ -153,7 +158,7 @@ public class FCMMessagePublisherTest {
     HttpPost httpUriRequest = httpUriRequests.get(0);
     String body = IOUtils.toString(httpUriRequest.getEntity().getContent(), "UTF-8");
     JSONObject jsonMessage = new JSONObject(body);
-    assertEquals(false, jsonMessage.getBoolean("validate_only"));
+    assertFalse(jsonMessage.getBoolean("validate_only"));
     JSONObject message = jsonMessage.getJSONObject("message");
     JSONObject data = message.getJSONObject("data");
     assertEquals("My Notification Title", data.getString("title"));
@@ -167,11 +172,12 @@ public class FCMMessagePublisherTest {
     assertNotNull(httpUriRequest);
     body = IOUtils.toString(httpUriRequest.getEntity().getContent(), "UTF-8");
     jsonMessage = new JSONObject(body);
-    assertEquals(false, jsonMessage.getBoolean("validate_only"));
+    assertFalse(jsonMessage.getBoolean("validate_only"));
     message = jsonMessage.getJSONObject("message");
     JSONObject notification = message.getJSONObject("notification");
     assertEquals("My Notification Title", notification.getString("title"));
     assertEquals("My Notification Body", notification.getString("body"));
+    assertEquals("5", notification.getString("badge"));
     data = message.getJSONObject("data");
     assertEquals("http://notification.url/target", data.getString("url"));
     assertEquals("token2", message.getString("token"));
@@ -190,7 +196,7 @@ public class FCMMessagePublisherTest {
     serverKeyParam.setName("serviceAccountFilePath");
     serverKeyParam.setValue(this.getClass().getResource("/fcm-test.json").getPath());
     initParams.addParameter(serverKeyParam);
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient) {
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient) {
       @Override
       protected PrivateKey getPrivateKeyFromPkcs8(String privateKeyPem) throws IOException {
         return mock(PrivateKey.class);
@@ -253,7 +259,7 @@ public class FCMMessagePublisherTest {
     serverKeyParam.setName("serviceAccountFilePath");
     serverKeyParam.setValue(this.getClass().getResource("/fcm-test.json").getPath());
     initParams.addParameter(serverKeyParam);
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient) {
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient) {
       @Override
       protected PrivateKey getPrivateKeyFromPkcs8(String privateKeyPem) throws IOException {
         return mock(PrivateKey.class);
@@ -317,7 +323,7 @@ public class FCMMessagePublisherTest {
     serverKeyParam.setName("serviceAccountFilePath");
     serverKeyParam.setValue(this.getClass().getResource("/fcm-test.json").getPath());
     initParams.addParameter(serverKeyParam);
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient) {
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient) {
       @Override
       protected PrivateKey getPrivateKeyFromPkcs8(String privateKeyPem) throws IOException {
         return mock(PrivateKey.class);
@@ -348,7 +354,7 @@ public class FCMMessagePublisherTest {
             new BasicStatusLine(new ProtocolVersion("", 1, 2), HttpStatus.SC_OK, ""));
     when(httpClient.execute(any())).thenReturn(httpResponse);
     InitParams initParams = buildInitParams();
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient) {
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient) {
       @Override
       protected PrivateKey getPrivateKeyFromPkcs8(String privateKeyPem) throws IOException {
         return mock(PrivateKey.class);
@@ -414,7 +420,7 @@ public class FCMMessagePublisherTest {
     when(httpResponse.getEntity()).thenReturn(httpEntity);
     when(httpClient.execute(any())).thenReturn(httpResponse);
     InitParams initParams = buildInitParams();
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient) {
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient) {
       @Override
       protected PrivateKey getPrivateKeyFromPkcs8(String privateKeyPem) throws IOException {
         return mock(PrivateKey.class);
@@ -452,7 +458,7 @@ public class FCMMessagePublisherTest {
     when(httpResponse.getEntity()).thenReturn(httpEntity);
     when(httpClient.execute(any())).thenReturn(httpResponse);
     InitParams initParams = buildInitParams();
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient) {
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient) {
       @Override
       protected PrivateKey getPrivateKeyFromPkcs8(String privateKeyPem) throws IOException {
         return mock(PrivateKey.class);
@@ -501,7 +507,7 @@ public class FCMMessagePublisherTest {
     when(httpResponse.getEntity()).thenReturn(httpEntity);
     when(httpClient.execute(any())).thenReturn(httpResponse);
     InitParams initParams = buildInitParams();
-    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, httpClient) {
+    FCMMessagePublisher messagePublisher = new FCMMessagePublisher(initParams, resourceBundleService, webNotificationService, httpClient) {
       @Override
       protected PrivateKey getPrivateKeyFromPkcs8(String privateKeyPem) throws IOException {
         return mock(PrivateKey.class);

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>org.exoplatform.addons.push-notifications</groupId>
     <artifactId>exo-push-notifications</artifactId>
-    <version>2.2.x-SNAPSHOT</version>
+    <version>2.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo-push-notifications-webapp</artifactId>
 


### PR DESCRIPTION
For iOS notification objects sent to Firebase, we need to add the number of unread messages to be able to display them on the application icon on iphones. a new attribute **badge** was added with value equal to the number of web notifications that are still unread