### PR TITLE
45308 : Update push notification to be compatible with new FCM API 

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -51,7 +51,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <artifactId>swagger-jaxrs</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -187,8 +187,6 @@ public class FCMMessagePublisher implements MessagePublisher {
             .append("  }")
             .append("}");
 
-    LOG.info("sent notification : \n" + requestBody + "\n");
-
     post.setEntity(new ByteArrayEntity(requestBody.toString().getBytes()));
 
     long startTimeSendingMessage = System.currentTimeMillis();

--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -174,12 +174,16 @@ public class FCMMessagePublisher implements MessagePublisher {
       String expirationHeader = "";
       if (fcmMessageExpirationTime != null) {
         Instant expirationInstant = Instant.now().minus(fcmMessageExpirationTime, ChronoUnit.SECONDS);
-        expirationHeader = "\"apns-expiration\": \"" + expirationInstant.getEpochSecond() + "\",";
+        expirationHeader = "      \"headers\": {" +
+                "        \"apns-expiration\": \"" + expirationInstant.getEpochSecond() + "\"" +
+                "      },";
       }
       requestBody.append("    \"apns\": {")
-              .append("      \"headers\": {")
               .append(expirationHeader)
-              .append("        \"badge\": \"").append(webNotificationService.getNumberOnBadge(message.getReceiver())).append("\"")
+              .append("      \"payload\": {")
+              .append("        \"aps\": {")
+              .append("          \"badge\": ").append(webNotificationService.getNumberOnBadge(message.getReceiver()))
+              .append("        }")
               .append("      }")
               .append("    },");
     }

--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -86,14 +86,14 @@ public class FCMMessagePublisher implements MessagePublisher {
     this(initParams, resourceBundleService, webNotificationService, HttpClientBuilder.create().build());
   }
 
-  public FCMMessagePublisher(InitParams initParams, ResourceBundleService resourceBundleService, WebNotificationService webNotificationService,  CloseableHttpClient httpClient) {
-    if(initParams != null) {
+  public FCMMessagePublisher(InitParams initParams, ResourceBundleService resourceBundleService, WebNotificationService webNotificationService, CloseableHttpClient httpClient) {
+    if (initParams != null) {
       // FCM configuration file
       ValueParam serviceAccountFilePathValueParam = initParams.getValueParam("serviceAccountFilePath");
-      if(serviceAccountFilePathValueParam != null) {
+      if (serviceAccountFilePathValueParam != null) {
         fcmServiceAccountFilePath = serviceAccountFilePathValueParam.getValue();
       }
-      if(StringUtils.isNotBlank(fcmServiceAccountFilePath)) {
+      if (StringUtils.isNotBlank(fcmServiceAccountFilePath)) {
         try {
           if (!fcmServiceAccountFilePath.startsWith("/")) {
             // relative path
@@ -119,7 +119,7 @@ public class FCMMessagePublisher implements MessagePublisher {
 
       // FCM message expiration
       ValueParam fcmMessageExpirationTimeValueParam = initParams.getValueParam("messageExpirationTime");
-      if(fcmMessageExpirationTimeValueParam != null && StringUtils.isNotBlank(fcmMessageExpirationTimeValueParam.getValue())) {
+      if (fcmMessageExpirationTimeValueParam != null && StringUtils.isNotBlank(fcmMessageExpirationTimeValueParam.getValue())) {
         try {
           fcmMessageExpirationTime = Integer.parseInt(fcmMessageExpirationTimeValueParam.getValue());
         } catch (NumberFormatException e) {
@@ -136,7 +136,7 @@ public class FCMMessagePublisher implements MessagePublisher {
 
   @Override
   public void send(Message message) throws Exception {
-    if(googleCredential == null) {
+    if (googleCredential == null) {
       return;
     }
 
@@ -151,71 +151,73 @@ public class FCMMessagePublisher implements MessagePublisher {
             .append("{")
             .append("  \"validate_only\": false,")
             .append("  \"message\": {");
-    if(StringUtils.isNotBlank(message.getDeviceType()) && message.getDeviceType().equals("android")) {
+    if (StringUtils.isNotBlank(message.getDeviceType()) && message.getDeviceType().equals("android")) {
       requestBody.append("    \"data\": {")
               .append("      \"title\": \"").append(message.getTitle().replaceAll("\"", "\\\\\"")).append("\",")
               .append("      \"body\": \"").append(messageBody).append("\",")
               .append("      \"url\": \"").append(message.getUrl()).append("\"")
               .append("    },");
+      if (fcmMessageExpirationTime != null) {
+        requestBody
+                .append("    \"android\": {")
+                .append("      \"ttl\": \"").append(fcmMessageExpirationTime).append("s\"")
+                .append("    },");
+      }
     } else {
       requestBody.append("    \"data\": {")
               .append("      \"url\": \"").append(message.getUrl()).append("\"")
               .append("    },")
               .append("    \"notification\": {")
-              .append("      \"title\": \"").append(message.getTitle().replaceAll("\\<[^>]*>","").replaceAll("\"", "\\\\\"")).append("\",")
-              .append("      \"body\": \"").append(messageBody.replaceAll("\\<[^>]*>","")).append("\",")
-              .append("      \"badge\": \"").append(webNotificationService.getNumberOnBadge(message.getReceiver())).append("\"")
+              .append("      \"title\": \"").append(message.getTitle().replaceAll("\\<[^>]*>", "").replaceAll("\"", "\\\\\"")).append("\",")
+              .append("      \"body\": \"").append(messageBody.replaceAll("\\<[^>]*>", "")).append("\"")
               .append("    },");
-    }
-    if(fcmMessageExpirationTime != null && StringUtils.isNotBlank(message.getDeviceType())) {
-      if(message.getDeviceType().equals("android")) {
-        requestBody
-                .append("    \"android\": {")
-                .append("      \"ttl\": \"").append(fcmMessageExpirationTime).append("s\"")
-                .append("    },");
-      } else if(message.getDeviceType().equals("ios")) {
+      String expirationHeader = "";
+      if (fcmMessageExpirationTime != null) {
         Instant expirationInstant = Instant.now().minus(fcmMessageExpirationTime, ChronoUnit.SECONDS);
-        requestBody
-                .append("    \"apns\": {")
-                .append("      \"headers\": {")
-                .append("        \"apns-expiration\": \"").append(expirationInstant.getEpochSecond()).append("\"")
-                .append("      }")
-                .append("    },");
+        expirationHeader = "\"apns-expiration\": \"" + expirationInstant.getEpochSecond() + "\",";
       }
+      requestBody.append("    \"apns\": {")
+              .append("      \"headers\": {")
+              .append(expirationHeader)
+              .append("        \"badge\": \"").append(webNotificationService.getNumberOnBadge(message.getReceiver())).append("\"")
+              .append("      }")
+              .append("    },");
     }
     requestBody.append("    \"token\":\"").append(message.getToken()).append("\"")
             .append("  }")
             .append("}");
 
+    LOG.info("sent notification : \n" + requestBody + "\n");
+
     post.setEntity(new ByteArrayEntity(requestBody.toString().getBytes()));
 
     long startTimeSendingMessage = System.currentTimeMillis();
 
-    try(CloseableHttpResponse response = httpClient.execute(post)) {
+    try (CloseableHttpResponse response = httpClient.execute(post)) {
       long sendMessageExecutionTime = System.currentTimeMillis() - startTimeSendingMessage;
       if (response == null || response.getStatusLine() == null) {
         String errorMessage = "Error sending Push Notification, HTTP response or HTTP response code is null";
-        LOG.info("remote_service={} operation={} parameters=\"user:{},token:{},type:{}\" status=ko duration_ms={} error_msg=\"{}\"", 
-                      LOG_SERVICE_NAME, LOG_OPERATION_NAME, message.getReceiver(), StringUtil.mask(message.getToken(), 4),
-                      message.getDeviceType(), sendMessageExecutionTime, errorMessage);
+        LOG.info("remote_service={} operation={} parameters=\"user:{},token:{},type:{}\" status=ko duration_ms={} error_msg=\"{}\"",
+                LOG_SERVICE_NAME, LOG_OPERATION_NAME, message.getReceiver(), StringUtil.mask(message.getToken(), 4),
+                message.getDeviceType(), sendMessageExecutionTime, errorMessage);
         throw new Exception(errorMessage);
       } else if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
         String errorMessage = "Error sending Push Notification, response is " + response.getStatusLine().getStatusCode()
-                      + " - " + response.getStatusLine().getReasonPhrase();
-        LOG.info("remote_service={} operation={} parameters=\"user:{},token:{},type:{}\" status=ko status_code={} duration_ms={} error_msg=\"{}\"", 
-                      LOG_SERVICE_NAME, LOG_OPERATION_NAME, message.getReceiver(), StringUtil.mask(message.getToken(), 4),
-                      message.getDeviceType(), response.getStatusLine().getStatusCode(), sendMessageExecutionTime, errorMessage);
+                + " - " + response.getStatusLine().getReasonPhrase();
+        LOG.info("remote_service={} operation={} parameters=\"user:{},token:{},type:{}\" status=ko status_code={} duration_ms={} error_msg=\"{}\"",
+                LOG_SERVICE_NAME, LOG_OPERATION_NAME, message.getReceiver(), StringUtil.mask(message.getToken(), 4),
+                message.getDeviceType(), response.getStatusLine().getStatusCode(), sendMessageExecutionTime, errorMessage);
 
         // check if the token is invalid to throw a specific exception
-        if(isTokenInvalid(response)) {
+        if (isTokenInvalid(response)) {
           throw new InvalidTokenException(errorMessage);
         }
         // otherwise throw a general exception
         throw new Exception(errorMessage);
       } else {
-        LOG.info("remote_service={} operation={} parameters=\"user:{},token:{},type:{}\" status=ok duration_ms={}", 
-                      LOG_SERVICE_NAME, LOG_OPERATION_NAME, message.getReceiver(), StringUtil.mask(message.getToken(), 4),
-                      message.getDeviceType(), sendMessageExecutionTime);
+        LOG.info("remote_service={} operation={} parameters=\"user:{},token:{},type:{}\" status=ok duration_ms={}",
+                LOG_SERVICE_NAME, LOG_OPERATION_NAME, message.getReceiver(), StringUtil.mask(message.getToken(), 4),
+                message.getDeviceType(), sendMessageExecutionTime);
         LOG.info("Message sent to Firebase : username={}, token={}, type={}",
                 message.getReceiver(), StringUtil.mask(message.getToken(), 4), message.getDeviceType());
       }
@@ -226,13 +228,14 @@ public class FCMMessagePublisher implements MessagePublisher {
    * Process the notification message body:
    * * replace images by a text "inline image"
    * * escape double quotes
+   *
    * @param message The raw message body
    * @return The transformed message body
    */
   protected String processBody(Message message) {
     String language = NotificationPluginUtils.getLanguage(message.getReceiver());
     Locale locale;
-    if(StringUtils.isNotEmpty(language)) {
+    if (StringUtils.isNotEmpty(language)) {
       locale = new Locale(language);
     } else {
       locale = Locale.ENGLISH;
@@ -249,28 +252,29 @@ public class FCMMessagePublisher implements MessagePublisher {
 
   /**
    * Check if the response states that the token is invalid
+   *
    * @param response The HTTP response content
    * @return true if the token is invalid
    * @throws IOException
    */
   private boolean isTokenInvalid(CloseableHttpResponse response) throws IOException {
-    if(response.getStatusLine().getStatusCode() == HttpStatus.SC_BAD_REQUEST) {
+    if (response.getStatusLine().getStatusCode() == HttpStatus.SC_BAD_REQUEST) {
       JacksonFactory jsonFactory = new JacksonFactory();
       JsonObjectParser parser = new JsonObjectParser(jsonFactory);
       FcmResponse responseContent = parser.parseAndClose(response.getEntity().getContent(), Charset.forName("UTF-8"), FcmResponse.class);
       FcmError error = responseContent.getError();
-      if(error != null) {
+      if (error != null) {
         String errorStatus = error.getStatus();
         if (errorStatus != null) {
           if (errorStatus.equals("UNREGISTERED")) {
             return true;
-          } else if(errorStatus.equals("INVALID_ARGUMENT")) {
+          } else if (errorStatus.equals("INVALID_ARGUMENT")) {
             List<FcmDetail> details = error.getDetails();
-            if(details != null) {
-              for(FcmDetail detail : details) {
+            if (details != null) {
+              for (FcmDetail detail : details) {
                 List<ArrayMap> fieldViolations = (List<ArrayMap>) detail.get("fieldViolations");
-                if(fieldViolations != null) {
-                  if(fieldViolations.stream()
+                if (fieldViolations != null) {
+                  if (fieldViolations.stream()
                           .anyMatch(fieldViolation -> fieldViolation.get("field") != null && fieldViolation.get("field").equals("message.token"))) {
                     return true;
                   }
@@ -302,10 +306,10 @@ public class FCMMessagePublisher implements MessagePublisher {
 
     GenericJson fileContents = parser.parseAndClose(fcmServiceAccountFile, Charset.forName("UTF-8"), GenericJson.class);
 
-    String clientId = (String)fileContents.get("client_id");
-    String clientEmail = (String)fileContents.get("client_email");
-    String privateKeyPem = (String)fileContents.get("private_key");
-    String privateKeyId = (String)fileContents.get("private_key_id");
+    String clientId = (String) fileContents.get("client_id");
+    String clientEmail = (String) fileContents.get("client_email");
+    String privateKeyPem = (String) fileContents.get("private_key");
+    String privateKeyId = (String) fileContents.get("private_key_id");
 
     if (clientId != null && clientEmail != null && privateKeyPem != null && privateKeyId != null) {
       FCMServiceAccountConfiguration fcmServiceAccountConfiguration = new FCMServiceAccountConfiguration();
@@ -314,12 +318,12 @@ public class FCMMessagePublisher implements MessagePublisher {
       fcmServiceAccountConfiguration.setServiceAccountPrivateKeyPem(privateKeyPem);
       fcmServiceAccountConfiguration.setServiceAccountPrivateKeyId(privateKeyId);
 
-      String projectId = (String)fileContents.get("project_id");
+      String projectId = (String) fileContents.get("project_id");
       if (projectId != null) {
         fcmServiceAccountConfiguration.setServiceAccountProjectId(projectId);
       }
 
-      String tokenUri = (String)fileContents.get("token_uri");
+      String tokenUri = (String) fileContents.get("token_uri");
       if (tokenUri != null) {
         fcmServiceAccountConfiguration.setTokenServerEncodedUrl(tokenUri);
       }
@@ -329,7 +333,6 @@ public class FCMMessagePublisher implements MessagePublisher {
       throw new IOException("Error reading service account configuration from file, expecting 'client_id', 'client_email', 'private_key' and 'private_key_id'.");
     }
   }
-
 
 
   /**
@@ -362,7 +365,7 @@ public class FCMMessagePublisher implements MessagePublisher {
       }
     }
 
-    if(setServiceAccountScopesMethod != null) {
+    if (setServiceAccountScopesMethod != null) {
       setServiceAccountScopesMethod.invoke(credentialBuilder, Collections.singletonList("https://www.googleapis.com/auth/firebase.messaging"));
     }
 

--- a/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
+++ b/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
@@ -183,9 +183,12 @@ public class FCMMessagePublisherTest {
     assertFalse(message.has("android"));
     assertTrue(message.has("apns"));
     JSONObject apns = message.getJSONObject("apns");
-    assertTrue(apns.has("headers"));
-    JSONObject headers = apns.getJSONObject("headers");
-    assertEquals("5", headers.getString("badge"));
+    assertTrue(apns.has("payload"));
+    JSONObject payload = apns.getJSONObject("payload");
+    assertTrue(payload.has("aps"));
+    JSONObject aps = payload.getJSONObject("aps");
+    assertTrue(aps.has("badge"));
+    assertEquals(5, aps.getInt("badge"));
   }
 
   @Test
@@ -250,9 +253,12 @@ public class FCMMessagePublisherTest {
     assertFalse(message.has("android"));
     assertTrue(message.has("apns"));
     JSONObject apns = message.getJSONObject("apns");
-    assertTrue(apns.has("headers"));
-    JSONObject headers = apns.getJSONObject("headers");
-    assertEquals("5", headers.getString("badge"));
+    assertTrue(apns.has("payload"));
+    JSONObject payload = apns.getJSONObject("payload");
+    assertTrue(payload.has("aps"));
+    JSONObject aps = payload.getJSONObject("aps");
+    assertTrue(aps.has("badge"));
+    assertEquals(5, aps.getInt("badge"));
   }
 
   @Test
@@ -317,9 +323,12 @@ public class FCMMessagePublisherTest {
     assertFalse(message.has("android"));
     assertTrue(message.has("apns"));
     JSONObject apns = message.getJSONObject("apns");
-    assertTrue(apns.has("headers"));
-    JSONObject headers = apns.getJSONObject("headers");
-    assertEquals("5", headers.getString("badge"));
+    assertTrue(apns.has("payload"));
+    JSONObject payload = apns.getJSONObject("payload");
+    assertTrue(payload.has("aps"));
+    JSONObject aps = payload.getJSONObject("aps");
+    assertTrue(aps.has("badge"));
+    assertEquals(5, aps.getInt("badge"));
   }
 
 

--- a/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
+++ b/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
@@ -177,12 +177,15 @@ public class FCMMessagePublisherTest {
     JSONObject notification = message.getJSONObject("notification");
     assertEquals("My Notification Title", notification.getString("title"));
     assertEquals("My Notification Body", notification.getString("body"));
-    assertEquals("5", notification.getString("badge"));
     data = message.getJSONObject("data");
     assertEquals("http://notification.url/target", data.getString("url"));
     assertEquals("token2", message.getString("token"));
     assertFalse(message.has("android"));
-    assertFalse(message.has("apns"));
+    assertTrue(message.has("apns"));
+    JSONObject apns = message.getJSONObject("apns");
+    assertTrue(apns.has("headers"));
+    JSONObject headers = apns.getJSONObject("headers");
+    assertEquals("5", headers.getString("badge"));
   }
 
   @Test
@@ -245,7 +248,11 @@ public class FCMMessagePublisherTest {
     assertEquals("http://notification.url/target", data.getString("url"));
     assertEquals("token2", message.getString("token"));
     assertFalse(message.has("android"));
-    assertFalse(message.has("apns"));
+    assertTrue(message.has("apns"));
+    JSONObject apns = message.getJSONObject("apns");
+    assertTrue(apns.has("headers"));
+    JSONObject headers = apns.getJSONObject("headers");
+    assertEquals("5", headers.getString("badge"));
   }
 
   @Test
@@ -308,7 +315,11 @@ public class FCMMessagePublisherTest {
     assertEquals("http://notification.url/target", data.getString("url"));
     assertEquals("token2", message.getString("token"));
     assertFalse(message.has("android"));
-    assertFalse(message.has("apns"));
+    assertTrue(message.has("apns"));
+    JSONObject apns = message.getJSONObject("apns");
+    assertTrue(apns.has("headers"));
+    JSONObject headers = apns.getJSONObject("headers");
+    assertEquals("5", headers.getString("badge"));
   }
 
 

--- a/service/src/test/resources/simplelogger.properties
+++ b/service/src/test/resources/simplelogger.properties
@@ -1,0 +1,14 @@
+# Set root logger level to DEBUG and its only appender to A1.
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
+org.slf4j.simpleLogger.showThreadName=false
+org.slf4j.simpleLogger.showLogName=true
+org.slf4j.simpleLogger.log.org.exoplatform.commons.notification.lifecycle.WebLifecycle=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.commons.notification.lifecycle.MailLifecycle=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.commons.notification.net.WebNotificationSender=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.social.core.space.impl.SpaceTemplateServiceImpl=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.AgendaTemplateBuilder=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.DatePollNotificationBuilder=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.ReminderTemplateBuilder=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.ReplyTemplateBuilder=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.VoteTemplateBuilder=ERROR


### PR DESCRIPTION
This PR adds the badge number respecting the Push notification for iOS that should respect the following format : 
```{
  "validate_only": false,
  "message": {
    "data": {
      "url": "Notif URL"
    },
    "notification": {
      "title": "eXo",
      "body": "Body of the message"
    },
    "apns": {
      "payload": {
        "aps": {
          "badge": 5
        }
      }
    },
    "token": ""
  }
}```