### PR TITLE
45308 : Add badge information to the iOS notification (#10)

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -51,7 +51,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <artifactId>swagger-jaxrs</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/service/src/test/resources/simplelogger.properties
+++ b/service/src/test/resources/simplelogger.properties
@@ -1,0 +1,14 @@
+# Set root logger level to DEBUG and its only appender to A1.
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
+org.slf4j.simpleLogger.showThreadName=false
+org.slf4j.simpleLogger.showLogName=true
+org.slf4j.simpleLogger.log.org.exoplatform.commons.notification.lifecycle.WebLifecycle=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.commons.notification.lifecycle.MailLifecycle=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.commons.notification.net.WebNotificationSender=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.social.core.space.impl.SpaceTemplateServiceImpl=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.AgendaTemplateBuilder=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.DatePollNotificationBuilder=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.ReminderTemplateBuilder=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.ReplyTemplateBuilder=ERROR
+org.slf4j.simpleLogger.log.org.exoplatform.agenda.notification.builder.VoteTemplateBuilder=ERROR


### PR DESCRIPTION
For iOS notification objects sent to Firebase, we need to add the number of unread messages to be able to display them on the application icon on iphones. a new attribute **badge** was added with value equal to the number of web notifications that are still unread

(cherry picked from commit c7f2181b36104a1a6b11738a8aa9af382baea54f)