### PR TITLE
task#51805: added regex to replace line returns with an empty character in ios me

### DIFF
--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -169,7 +169,7 @@ public class FCMMessagePublisher implements MessagePublisher {
               .append("    },")
               .append("    \"notification\": {")
               .append("      \"title\": \"").append(message.getTitle().replaceAll("\\<[^>]*>", "").replaceAll("\"", "\\\\\"")).append("\",")
-              .append("      \"body\": \"").append(messageBody.replaceAll("\\<[^>]*>", "")).append("\"")
+              .append("      \"body\": \"").append(messageBody.replaceAll("\\<[^>]*>|\\n", "").trim()).append("\"")
               .append("    },");
       String expirationHeader = "";
       if (fcmMessageExpirationTime != null) {

--- a/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
+++ b/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
@@ -217,7 +217,13 @@ public class FCMMessagePublisherTest {
 
     // When
     messagePublisher.send(new Message("john", "token1", "android", "My <b>Notification</b> Title", "My Notification <div class=\"myclass\">Body</div>", "http://notification.url/target"));
-    messagePublisher.send(new Message("mary", "token2", "ios", "My <b>Notification</b> Title", "My Notification <div class=\"myclass\">Body</div>", "http://notification.url/target"));
+    messagePublisher.send(new Message("mary", "token2", "ios", "My <b>Notification</b> Title",
+            "\n" +
+                    "\n" +
+                    "My Notification \n" +
+                    "\n" +
+                    "<div class=\"myclass\">Body</div>",
+            "http://notification.url/target"));
 
     // Then
     verify(httpClient, times(2)).execute(reqArgs.capture());
@@ -241,7 +247,7 @@ public class FCMMessagePublisherTest {
     httpUriRequest = httpUriRequests.get(1);
     assertNotNull(httpUriRequest);
     body = IOUtils.toString(httpUriRequest.getEntity().getContent(), "UTF-8");
-    jsonMessage = new JSONObject(body);
+    jsonMessage = new JSONObject(body.replaceAll("\\n", "\\\\n"));
     assertEquals(false, jsonMessage.getBoolean("validate_only"));
     message = jsonMessage.getJSONObject("message");
     JSONObject notification = message.getJSONObject("notification");


### PR DESCRIPTION
ISSUE: push notifications show up empty in the ios application
FIX: added regex to remove line returns for ios  notification's message body