### PR TITLE
EXO-53225 : Fix ExpiredMessagingTokensCleaner periodicity (#22)

### DIFF
--- a/service/src/main/resources/conf/portal/configuration.xml
+++ b/service/src/main/resources/conf/portal/configuration.xml
@@ -89,7 +89,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <property name="groupName" value="Messaging"/>
           <property name="job" value="org.exoplatform.push.job.ExpiredTokensCleanerJob"/>
           <property name="repeatCount" value="0"/>
-          <property name="period" value="${exo.messaging.token.cleaner.job.period:86400000}"/>
+          <property name="period" value="${exo.messaging.token.cleaner.job.period:28800000}"/> <!-- Job period is 8 hours -->
           <property name="startTime" value="+60000"/><!-- start after 1 minute delay -->
           <property name="endTime" value=""/>
         </properties-param>


### PR DESCRIPTION
When the server is restarted daily, the ExpiredMessagingTokensCleaner never runs. This is caused by the wrong configuration used, It is a periodic job that runs once daily with a delay of 1 mn after server start. But since the server is restarted once a day at the same time , the job will never run.
The fix will change the periodicity to 8 hours.