### PR TITLE
Task-52792: Mobile - iOS - Space missing after the first sentence on the push notification (#25)

### DIFF
--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -44,6 +44,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
+import org.jsoup.Jsoup;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -66,7 +67,6 @@ public class FCMMessagePublisher implements MessagePublisher {
 
   public final static String LOG_SERVICE_NAME = "firebase-cloud-messaging";
   public final static String LOG_OPERATION_NAME = "send-push-notification";
-
   private ResourceBundleService resourceBundleService;
 
   private WebNotificationService webNotificationService;
@@ -169,7 +169,7 @@ public class FCMMessagePublisher implements MessagePublisher {
               .append("    },")
               .append("    \"notification\": {")
               .append("      \"title\": \"").append(message.getTitle().replaceAll("\\<[^>]*>", "").replaceAll("\"", "\\\\\"")).append("\",")
-              .append("      \"body\": \"").append(messageBody.replaceAll("\\<[^>]*>|\\n", "").trim()).append("\"")
+              .append("      \"body\": \"").append((Jsoup.parse(messageBody).wholeText()).trim()).append("\"")
               .append("    },");
       String expirationHeader = "";
       if (fcmMessageExpirationTime != null) {

--- a/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
+++ b/service/src/test/java/org/exoplatform/push/service/fcm/FCMMessagePublisherTest.java
@@ -252,7 +252,7 @@ public class FCMMessagePublisherTest {
     message = jsonMessage.getJSONObject("message");
     JSONObject notification = message.getJSONObject("notification");
     assertEquals("My Notification Title", notification.getString("title"));
-    assertEquals("My Notification Body", notification.getString("body"));
+    assertEquals("My Notification \n\nBody", notification.getString("body"));
     data = message.getJSONObject("data");
     assertEquals("http://notification.url/target", data.getString("url"));
     assertEquals("token2", message.getString("token"));


### PR DESCRIPTION
ISSUE: space missing after the first sentence on the push notification
FIX: replaced the html element for the message body with a space so that here will be a space between the notif title and message