### PR TITLE
task-54827: conserve line breaks in a html document (#27)

### DIFF
--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -45,6 +45,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.social.notification.plugin.SocialNotificationUtils;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -169,7 +170,7 @@ public class FCMMessagePublisher implements MessagePublisher {
               .append("    },")
               .append("    \"notification\": {")
               .append("      \"title\": \"").append(message.getTitle().replaceAll("\\<[^>]*>", "").replaceAll("\"", "\\\\\"")).append("\",")
-              .append("      \"body\": \"").append((Jsoup.parse(messageBody).wholeText()).trim()).append("\"")
+              .append("      \"body\": \"").append((Jsoup.parse(convertHtml(messageBody)).wholeText()).trim()).append("\"")
               .append("    },");
       String expirationHeader = "";
       if (fcmMessageExpirationTime != null) {
@@ -224,6 +225,18 @@ public class FCMMessagePublisher implements MessagePublisher {
                 message.getReceiver(), StringUtil.mask(message.getToken(), 4), message.getDeviceType());
       }
     }
+  }
+  /**
+   *Conserve line breaks of br and p elements in a html document 
+   */
+  protected String convertHtml(String html) {
+	if(html==null)
+	    return html;
+	Document document = Jsoup.parse(html);
+	document.outputSettings(new Document.OutputSettings().prettyPrint(false));
+	document.select("br").append("\\n");
+	document.select("p").prepend("\\n\\n");
+	return document.html();
   }
 
   /**


### PR DESCRIPTION
ISSUE: before sending a push notification messgae body to an ios device, we need the extract the text from the html because ios can't parse html as opposed to android.
This step of removing the html also remove any formatting for our push notification text

FIX: conserve our html formatting by converting p and br elements to \n so that the structure of the text appears as close as possible to the html.
(cherry picked from commit 593fb15d502e4a9c2eff07f91f574c6a39107e3e)