### PR TITLE
TASK-56851: Fix push notification message in spaceInvitaionPlugin

### DIFF
--- a/war/src/main/webapp/WEB-INF/push-notifications/templates/SpaceInvitationPlugin.gtmpl
+++ b/war/src/main/webapp/WEB-INF/push-notifications/templates/SpaceInvitationPlugin.gtmpl
@@ -17,6 +17,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <%
   String message = (STATUS == "ACCEPTED") ?
           _ctx.appRes("Notification.intranet.message.accept.SpaceInvitationPlugin", SPACE)
-          : _ctx.appRes("Notification.intranet.message.SpaceInvitationPlugin", SPACE);
+          : _ctx.appRes("Notification.intranet.message.SpaceInvitationPlugin", SENDER_NAME, SPACE);
 %>
 $message


### PR DESCRIPTION
Prior to this change, when send and inivation to a user to join the space the push notifi message doesn't display the sender name correctly and instead displays the space name as sender and {1} as space name.
This Pr should add the missed param of sender name in the message key to correctly display the sender and the space name