### PR TITLE
fix: add company name from Branding service for the Push notification title to fix NPE - EXO-63726 - Meeds-io/meeds#904

### DIFF
--- a/service/src/main/java/org/exoplatform/push/channel/PushChannel.java
+++ b/service/src/main/java/org/exoplatform/push/channel/PushChannel.java
@@ -24,6 +24,7 @@ import org.exoplatform.commons.api.notification.model.ChannelKey;
 import org.exoplatform.commons.api.notification.model.MessageInfo;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.portal.branding.BrandingService;
 import org.exoplatform.push.domain.Device;
 import org.exoplatform.push.domain.Message;
 import org.exoplatform.push.exception.InvalidTokenException;
@@ -46,8 +47,6 @@ public class PushChannel extends AbstractChannel {
   public final static String LOG_SERVICE_NAME = "notifications";
   public final static String LOG_OPERATION_NAME = "send-push-notification";
 
-  public String notificationTitle;
-
   private final ChannelKey key = ChannelKey.key(ID);
 
   private final Map<PluginKey, String> templateFilePaths = new HashMap<PluginKey, String>();
@@ -57,12 +56,12 @@ public class PushChannel extends AbstractChannel {
   private MessagePublisher messagePublisher;
 
   private DeviceService deviceService;
+  private BrandingService brandingService;
 
-  public PushChannel(MessagePublisher messagePublisher, DeviceService deviceService) {
+  public PushChannel(MessagePublisher messagePublisher, DeviceService deviceService, BrandingService brandingService) {
     this.messagePublisher = messagePublisher;
     this.deviceService = deviceService;
-
-    this.notificationTitle = System.getProperty("exo.notifications.portalname");
+    this.brandingService = brandingService;
   }
 
   @Override
@@ -95,7 +94,7 @@ public class PushChannel extends AbstractChannel {
               String maskedToken = StringUtil.mask(device.getToken(), 4);
               LOG.info("Sending push notification to user {} (token={})",
                       userId, maskedToken);
-              Message message = new Message(userId, device.getToken(), device.getType(), notificationTitle, messageInfo.getBody(), messageInfo.getSubject());
+              Message message = new Message(userId, device.getToken(), device.getType(), brandingService.getCompanyName(), messageInfo.getBody(), messageInfo.getSubject());
               messagePublisher.send(message);
               long sendMessageExecutionTime = System.currentTimeMillis() - startTimeSendingMessage;
               LOG.info("service={} operation={} parameters=\"user:{},token:{},type:{},pluginId:{}\" status=ok duration_ms={}", 

--- a/service/src/test/java/org/exoplatform/push/channel/PushChannelTest.java
+++ b/service/src/test/java/org/exoplatform/push/channel/PushChannelTest.java
@@ -19,6 +19,7 @@ package org.exoplatform.push.channel;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.portal.branding.BrandingService;
 import org.exoplatform.push.domain.Device;
 import org.exoplatform.push.domain.Message;
 import org.exoplatform.push.exception.InvalidTokenException;
@@ -43,13 +44,14 @@ public class PushChannelTest {
     // Given
     MessagePublisher messagePublisher = mock(FCMLegacyAPIMessagePublisher.class);
     DeviceService deviceService = mock(DeviceService.class);
+    BrandingService brandingService = mock(BrandingService.class);
     NotificationContext ctx = mock(NotificationContext.class);
     NotificationInfo notificationInfo = mock(NotificationInfo.class);
     when(notificationInfo.getKey()).thenReturn(new PluginKey("pluginId"));
     when(ctx.getNotificationInfo()).thenReturn(notificationInfo);
     when(deviceService.getDevicesByUser(anyString())).thenReturn(null);
 
-    PushChannel pushChannel = new PushChannel(messagePublisher, deviceService);
+    PushChannel pushChannel = new PushChannel(messagePublisher, deviceService, brandingService);
 
     // When
     pushChannel.dispatch(ctx, "john");
@@ -64,12 +66,13 @@ public class PushChannelTest {
     MessagePublisher messagePublisher = mock(FCMLegacyAPIMessagePublisher.class);
     DeviceService deviceService = mock(DeviceService.class);
     NotificationContext ctx = mock(NotificationContext.class);
+    BrandingService brandingService = mock(BrandingService.class);
     NotificationInfo notificationInfo = mock(NotificationInfo.class);
     when(notificationInfo.getKey()).thenReturn(new PluginKey("pluginId"));
     when(ctx.getNotificationInfo()).thenReturn(notificationInfo);
     when(deviceService.getDevicesByUser(anyString())).thenReturn(new ArrayList<>());
 
-    PushChannel pushChannel = new PushChannel(messagePublisher, deviceService);
+    PushChannel pushChannel = new PushChannel(messagePublisher, deviceService, brandingService);
 
     // When
     pushChannel.dispatch(ctx, "john");
@@ -84,12 +87,13 @@ public class PushChannelTest {
     MessagePublisher messagePublisher = mock(FCMLegacyAPIMessagePublisher.class);
     DeviceService deviceService = mock(DeviceService.class);
     NotificationContext ctx = mock(NotificationContext.class);
+    BrandingService brandingService = mock(BrandingService.class);
     NotificationInfo notificationInfo = mock(NotificationInfo.class);
     when(notificationInfo.getKey()).thenReturn(new PluginKey("pluginId"));
     when(ctx.getNotificationInfo()).thenReturn(notificationInfo);
     when(deviceService.getDevicesByUser(anyString())).thenReturn(Arrays.asList(new Device(), new Device()));
 
-    PushChannel pushChannel = new PushChannel(messagePublisher, deviceService);
+    PushChannel pushChannel = new PushChannel(messagePublisher, deviceService, brandingService);
 
     ArgumentCaptor<Message> messageArgs = ArgumentCaptor.forClass(Message.class);
 
@@ -109,6 +113,7 @@ public class PushChannelTest {
     MessagePublisher messagePublisher = mock(FCMLegacyAPIMessagePublisher.class);
     DeviceService deviceService = mock(DeviceService.class);
     NotificationContext ctx = mock(NotificationContext.class);
+    BrandingService brandingService = mock(BrandingService.class);
     NotificationInfo notificationInfo = mock(NotificationInfo.class);
     doThrow(new InvalidTokenException()).when(messagePublisher).send(any(Message.class));
     when(notificationInfo.getKey()).thenReturn(new PluginKey("pluginId"));
@@ -117,7 +122,7 @@ public class PushChannelTest {
     device.setToken("token1");
     when(deviceService.getDevicesByUser(anyString())).thenReturn(Arrays.asList(device));
 
-    PushChannel pushChannel = new PushChannel(messagePublisher, deviceService);
+    PushChannel pushChannel = new PushChannel(messagePublisher, deviceService, brandingService);
 
     // When
     pushChannel.dispatch(ctx, "john");


### PR DESCRIPTION
a NullPointerException is thrown whenever a new push notification is prepared to be sent. It is caused by missing System property which is no more needed as the information is already available in the Branding service
The fix fills the notification title by retrieving the company name from the branding service.