### PR TITLE
fix: add activity/comment link for push notification - EXO-67587 - Meeds-io/meeds#1299

### DIFF
--- a/service/src/main/java/org/exoplatform/push/channel/PushChannel.java
+++ b/service/src/main/java/org/exoplatform/push/channel/PushChannel.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.push.channel;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.channel.AbstractChannel;
 import org.exoplatform.commons.api.notification.channel.template.AbstractTemplateBuilder;
@@ -94,6 +95,11 @@ public class PushChannel extends AbstractChannel {
               String maskedToken = StringUtil.mask(device.getToken(), 4);
               LOG.info("Sending push notification to user {} (token={})",
                       userId, maskedToken);
+              if(StringUtils.isBlank(messageInfo.getSubject())) {
+                if(LOG.isDebugEnabled()) {
+                  LOG.warn("No URL provided for notification type {}", messageInfo.getPluginId());
+                }
+              }
               Message message = new Message(userId, device.getToken(), device.getType(), brandingService.getCompanyName(), messageInfo.getBody(), messageInfo.getSubject());
               messagePublisher.send(message);
               long sendMessageExecutionTime = System.currentTimeMillis() - startTimeSendingMessage;

--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -34,6 +34,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.exoplatform.commons.api.notification.plugin.NotificationPluginUtils;
 import org.exoplatform.commons.api.notification.service.WebNotificationService;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.push.domain.Message;
@@ -147,6 +148,9 @@ public class FCMMessagePublisher implements MessagePublisher {
     post.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
     String messageBody = processBody(message);
+    if(StringUtils.isEmpty(message.getUrl())) {
+      message.setUrl(CommonsUtils.getCurrentDomain());
+    }
 
     StringBuilder requestBody = new StringBuilder()
             .append("{")


### PR DESCRIPTION
Push notifications require that we put the notification link in the subject property to be used later as the link to redirect to when a user clicks on the received notification on their phones.
This fix makes sure that the link is added ion each notification otherwise, the curret server URL (Home) will be opened.
