### PR TITLE
feat: Cleanup Dependencies to rely on Spring Dependencies Tree - Meeds-io/MIPs#57

### DIFF
--- a/service/src/main/java/org/exoplatform/push/channel/PushChannel.java
+++ b/service/src/main/java/org/exoplatform/push/channel/PushChannel.java
@@ -16,7 +16,7 @@
  */
 package org.exoplatform.push.channel;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.channel.AbstractChannel;
 import org.exoplatform.commons.api.notification.channel.template.AbstractTemplateBuilder;

--- a/service/src/main/java/org/exoplatform/push/channel/template/PushTemplateProvider.java
+++ b/service/src/main/java/org/exoplatform/push/channel/template/PushTemplateProvider.java
@@ -21,8 +21,9 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.NotificationMessageUtils;
 import org.exoplatform.commons.api.notification.annotation.TemplateConfig;
@@ -187,7 +188,7 @@ public class PushTemplateProvider extends TemplateProvider {
 
     private String cutStringByMaxLength(String st, int maxLength) {
       if (st == null) return st;
-      st = StringEscapeUtils.unescapeHtml(st);
+      st = StringEscapeUtils.unescapeHtml4(st);
       if (st.length() <= maxLength) return st;
       String noHtmlSt = st.replaceAll("\\<.*?\\>", "");
       if (noHtmlSt.length() <= maxLength) return noHtmlSt;
@@ -360,7 +361,7 @@ public class PushTemplateProvider extends TemplateProvider {
 
     private String cutStringByMaxLength(String st, int maxLength) {
       if (st == null) return st;
-      st = StringEscapeUtils.unescapeHtml(st);
+      st = StringEscapeUtils.unescapeHtml4(st);
       if (st.length() <= maxLength) return st;
       String noHtmlSt = st.replaceAll("\\<.*?\\>", "");
       if (noHtmlSt.length() <= maxLength) return noHtmlSt;

--- a/service/src/main/java/org/exoplatform/push/dao/DeviceDao.java
+++ b/service/src/main/java/org/exoplatform/push/dao/DeviceDao.java
@@ -19,9 +19,9 @@ package org.exoplatform.push.dao;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.push.domain.Device;
 
-import javax.persistence.NoResultException;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import java.util.Date;
 import java.util.List;
 

--- a/service/src/main/java/org/exoplatform/push/domain/Device.java
+++ b/service/src/main/java/org/exoplatform/push/domain/Device.java
@@ -42,7 +42,7 @@ import java.util.Date;
 public class Device {
 
   @Id
-  @SequenceGenerator(name="SEQ_MSG_DEVICES_ID", sequenceName="SEQ_MSG_DEVICES_ID")
+  @SequenceGenerator(name="SEQ_MSG_DEVICES_ID", sequenceName="SEQ_MSG_DEVICES_ID", allocationSize = 1)
   @GeneratedValue(strategy=GenerationType.AUTO, generator="SEQ_MSG_DEVICES_ID")
   @Column(name = "ID")
   private long id;

--- a/service/src/main/java/org/exoplatform/push/domain/Device.java
+++ b/service/src/main/java/org/exoplatform/push/domain/Device.java
@@ -18,7 +18,7 @@ package org.exoplatform.push.domain;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 @Entity(name = "PushNotifsDevice")

--- a/service/src/main/java/org/exoplatform/push/rest/DeviceRestService.java
+++ b/service/src/main/java/org/exoplatform/push/rest/DeviceRestService.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.push.domain.Device;
 import org.exoplatform.push.service.DeviceService;

--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMLegacyAPIMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMLegacyAPIMessagePublisher.java
@@ -16,7 +16,7 @@
  */
 package org.exoplatform.push.service.fcm;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;

--- a/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
+++ b/service/src/main/java/org/exoplatform/push/service/fcm/FCMMessagePublisher.java
@@ -24,7 +24,7 @@ import com.google.api.client.json.jackson.JacksonFactory;
 import com.google.api.client.util.ArrayMap;
 import com.google.api.client.util.PemReader;
 import com.google.api.client.util.SecurityUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;

--- a/service/src/main/resources/db/changelog/push-notifications.db.changelog-1.0.0.xml
+++ b/service/src/main/resources/db/changelog/push-notifications.db.changelog-1.0.0.xml
@@ -62,6 +62,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <changeSet author="push-notifications" id="1.0.0-3" dbms="oracle,postgresql">
         <createSequence sequenceName="SEQ_MSG_DEVICES_ID" startValue="1"/>
     </changeSet>
+    <changeSet author="push-notifications" id="1.0.0-4" dbms="hsqldb">
+        <createSequence sequenceName="SEQ_MSG_DEVICES_ID" startValue="1"/>
+    </changeSet>
 
 
 


### PR DESCRIPTION
This change will upgrade from Commons Lang to Apache Lang 3 and will recompute the score of Tests coverage after excluding globally the POJOs from computation scopre computing. ( see Meeds-io/maven-parent-pom#45 )

(Resolves Meeds-io/MIPs#57)