### PR TITLE
feat: Retrieve Resource Bundle from extension context instead of Monolith - MEED-7237 - Meeds-io/MIPs#134

### DIFF
--- a/war/src/main/webapp/WEB-INF/web.xml
+++ b/war/src/main/webapp/WEB-INF/web.xml
@@ -37,6 +37,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <url-pattern>*.css</url-pattern>
     <url-pattern>*.js</url-pattern>
     <url-pattern>*.html</url-pattern>
+    <url-pattern>/i18n/*</url-pattern>
     <url-pattern>/images/*</url-pattern>
   </filter-mapping>
 


### PR DESCRIPTION
This change will allow to request the resource bundle from extension context using  declared as a filter in the  file.